### PR TITLE
Fixes submodule version, unused memory in Sensor

### DIFF
--- a/lib/sensor/MultiVoltage.h
+++ b/lib/sensor/MultiVoltage.h
@@ -13,7 +13,7 @@ class MultiVoltage: public Sensor<float*> {
   /**
    * @brief Read all voltages from the multiplexer
    */
-  void read();
+  void read() override;
 
   /**
    * @brief Get the last read character from the serial port

--- a/lib/sensor/Sensor.h
+++ b/lib/sensor/Sensor.h
@@ -6,12 +6,6 @@
 template <typename T>
 class Sensor : public Readable {
 public:
-  /**
-   * @brief Read from sensor, and value
-   * 
-   * @return The value read from the sensor 
-   */
-  void read();
 
   /**
    * @brief Get the last read value of the sensor
@@ -19,9 +13,8 @@ public:
    * @return The last read value of the sensor
    */
   virtual T getValue()=0;
-
-private:
-  T value;
+  protected:
+    T value;
 };
 
 

--- a/lib/sensor/SerialInput.h
+++ b/lib/sensor/SerialInput.h
@@ -22,10 +22,6 @@ class SerialInput: public Sensor<char> {
    * @return The last read character from the serial port
    */
   char getValue() override;
-
-
-  private:
-  char value;         // Last read character
 };
 
 

--- a/lib/sensor/SerialInput.h
+++ b/lib/sensor/SerialInput.h
@@ -14,7 +14,7 @@ class SerialInput: public Sensor<char> {
    * @brief Read and return one character from the serial port if available,
    * otherwise return '\0'
    */
-  void read();
+  void read() override;
 
   /**
    * @brief Get the last read character from the serial port

--- a/lib/sensor/Voltage.h
+++ b/lib/sensor/Voltage.h
@@ -37,7 +37,6 @@ float getValue() override;
 uint8_t getId();
 
 private:
-    float value;
     uint8_t id;
     uint8_t muxIndex;
 };

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ board = nano_every
 framework = arduino
 build_flags = 
     -Ilib/
+    -Ilib/fcp-common/src
 
 [env:native]
 platform = native

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,5 +1,5 @@
 #include "Arduino.h"
-#include "fcp-common/fcp-common.h"
+#include "fcp-common.h"
 
 #define LED 13
 


### PR DESCRIPTION
- changed accessibility of `T value` field in `class Sensor<T>` to protected -- derived Sensor classes couldn't use it because it was private and so it was just wasted memory 
- removes unnecessary redeclaration of read() method in Sensor.h
- updated fcp-common to 20 voltage cells to fix a cloning / submodule issue
- note: you might want to consider initializing Queen::voltageSettings array programmatically so you don't have to change that block of code every time you modify the number of fuel cells